### PR TITLE
Use constructor entrypoint and add set_price command

### DIFF
--- a/docs/deploy_guide.md
+++ b/docs/deploy_guide.md
@@ -35,7 +35,7 @@ Output:
 Installed WASM hash: b81e...
 ```
 
-### 1.1 Create contract (call `init`)
+### 1.1 Create contract (call `__constructor`)
 
 ```bash
 stellar contract deploy \
@@ -44,7 +44,7 @@ stellar contract deploy \
   --rpc-url https://soroban-testnet.stellar.org \
   --network-passphrase "Test SDF Network ; September 2015" \
   --source-account oracle-deployer \
-  -- \
+  -- __constructor \
     admin=GASVLW5YQFHEZJPNV2OQQ3P6CBD5Z5IW3XDAPEGSS6BMQZ35WZHCSKNB \
     assets='[{"Symbol":"USDC"},{"Symbol":"BLND"}]' \
     decimals=6 \
@@ -71,4 +71,16 @@ stellar contract invoke \
   --network-passphrase "Test SDF Network ; September 2015" \
   --source-account oracle-deployer \
   -- resolution
+```
+
+### 1.4 Publicar precios con `set_price`
+
+```bash
+stellar contract invoke \
+  --id CDLR6TLYLADGOZFDMWEWOY5NLKIDQ2Y3K62OXX47ZWQARLVRYLFS2CNW \
+  --network testnet \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015" \
+  --source-account oracle-deployer \
+  -- set_price prices='[1000000,2000000]' timestamp=1728000000
 ```

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -21,7 +21,13 @@ impl OracleAggregator {
     //
     // ### Errors
     // * `InvalidMaxAge` - The max age is not between 360 (6m) and 3600 (60m)
-    pub fn init(e: Env, admin: Address, base: Asset, decimals: u32, max_age: u64) {
+    pub fn __constructor(
+        e: Env,
+        admin: Address,
+        base: Asset,
+        decimals: u32,
+        max_age: u64,
+    ) {
         storage::extend_instance(&e);
         storage::set_admin(&e, &admin);
         storage::set_base(&e, &base);
@@ -30,6 +36,11 @@ impl OracleAggregator {
             panic_with_error!(&e, OracleAggregatorErrors::InvalidMaxAge);
         }
         storage::set_max_age(&e, &max_age);
+    }
+
+    // Backwards compatibility with older deploy tooling.
+    pub fn init(e: Env, admin: Address, base: Asset, decimals: u32, max_age: u64) {
+        Self::__constructor(e, admin, base, decimals, max_age);
     }
 
     /**** Read Only *****/

--- a/src/oracle/mod.rs
+++ b/src/oracle/mod.rs
@@ -7,7 +7,7 @@ pub struct CustomOracle;
 
 #[contractimpl]
 impl CustomOracle {
-    pub fn init(
+    pub fn __constructor(
         e: Env,
         admin: Address,
         assets: Vec<Asset>,
@@ -19,6 +19,16 @@ impl CustomOracle {
         storage::set_decimals(&e, &decimals);
         storage::set_resolution(&e, &resolution);
         storage::set_last_timestamp(&e, &0u64);
+    }
+
+    pub fn init(
+        e: Env,
+        admin: Address,
+        assets: Vec<Asset>,
+        decimals: u32,
+        resolution: u32,
+    ) {
+        Self::__constructor(e, admin, assets, decimals, resolution);
     }
 
     pub fn set_price(e: Env, prices: Vec<i128>, timestamp: u64) {


### PR DESCRIPTION
## Summary
- switch contract `init` functions to `__constructor`
- keep `init` for compatibility
- document deploying with `__constructor`
- document invoking `set_price`

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_b_685b4d8c91a0832084063513ce7ee4d2