### PR TITLE
feat: Add function to retrieve user debt for a specific asset

### DIFF
--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -594,4 +594,21 @@ impl Pool for PoolContract {
 
         pool::bad_debt(&e, &user);
     }
+
+    /// Returns the amount a user has borrowed for a specific asset.
+    ///
+    /// ### Arguments
+    /// * `user` - The address of the user
+    /// * `asset` - The address of the asset to query
+    ///
+    /// Returns the liability amount in share units (i128), or 0 if the user has no borrow for that asset.
+    fn get_user_debt_for_asset(e: Env, user: Address, asset: Address) -> i128 {
+        let reserve_list = storage::get_res_list(&e);
+        let positions = storage::get_user_positions(&e, &user);
+
+        match reserve_list.iter().position(|a| a == &asset) {
+            Some(index) => positions.liabilities.get(index as u32).unwrap_or(0),
+            None => 0,
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request for TrustBridge - Close Issue

❗ **Pull Request Information**

This pull request adds a new feature to the pool's main contract that allows users to check how much they have borrowed in a specific asset. The feature improves visibility and auditing capabilities regarding users' debt positions within the system.

## 🌀 Summary of Changes

- ✅ The `get_user_debt_for_asset` function was added to the main contract (`contract.rs`) in the `pool` module.
- Given a user and an asset, the function returns the amount borrowed in that asset.
- This function is exposed as part of the `Pool` trait, making it publicly accessible.

## 🛠 Testing

### Evidence Before Solution

Prior to this feature, there was no direct way to obtain how much a user had borrowed per asset from the contract. This required complex external queries or manual data combinations.

- **Video**: [Link to Loom video](https://loom.com)

### Evidence After Solution

Now, when calling `get_user_debt_for_asset(env, user, asset)`, you directly obtain the amount corresponding to the user's debt in that asset, or 0 if they have no debt in that asset.

- **Video**: [Link to Loom video](https://loom.com)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public query to retrieve a user’s debt for a specific asset in the Pool contract.
  - Returns a numeric value representing the user’s liability; responds with 0 when the asset isn’t found or no debt exists.
  - Improves integrator and UI capabilities for displaying per-asset borrowing data and handling edge cases consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->